### PR TITLE
Use tinted-builder-rust for weekly builds

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
-        uses: tinted-theming/base16-builder-go@latest
+        uses: tinted-theming/tinted-builder-rust@latest
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This repository includes a [GitHub Action][4] that builds the
+This repository includes a [GitHub Action] that builds the
 colorschemes once a week. This keeps the colorschemes up-to-date
 automatically.
 
@@ -8,60 +8,29 @@ automatically.
 
 ### Dependencies
 
-- `>=0.2.0` [base16-builder-go][1]
-- golang `>=1.16` to build base16-builder-go
+- `>=0.9.3` [tinted-builder-rust]
 
 ### Usage for template editing
 
-1. Clone [base16-builder-go][1] somewhere on your system.
-1. Run `cd /path/to/base-builder-go && go build` to generate a binary:
-`/path/to/base-builder-go/base16-builder-go`
-1. Now execute the binary you generated while giving the `-template-dir`
-arg the path to `base16-qutebrowser` repository: `./base16-builder-go
--template-dir ../base16-qutebrowser`
-
-Or the above steps represented in shell commands:
-
-```shell 
-cd /path/to/base16-qutebrowser/../ # This repos parent dir 
-git clone git@github.com:tinted-theming/base16-builder-go.git
-cd base16-builder-go
-go build ./base16-builder-go/base16-builder-go \
-  -template-dir ../base16-qutebrowser
-```
+1. Install [tinted-builder-rust]
+1. `tinted-builder-rust build path/to/base16-qutebrowser`
 
 ### Usage for adding or editing a colorscheme
 
-If you want to add or edit a colorscheme but want to test it out, you
-simply need to pass in your local [base16-schemes][2] directory when
-executing the `base16-builder-go` binary.
+1. Clone the base16-qutebrowser
+1. Clone [tinted-schemes]
+1. Install [tinted-builder-rust]
+1. Execute `tinted-builder-rust build base16-qutebrowser` with
+  - `--schemes-dir` arg - provide `/path/to/tinted-schemes`
 
 ```shell
-base16-builder-go \
-  -schemes-dir /path/to/base16-schemes \
-  -template-dir /path/to/base16-qutebrowser
+tinted-builder-rust build /path/to/base16-qutebrowser \
+  --schemes-dir /path/to/tinted-schemes
 ```
 
-If you have more questions about [base16-builder-go][1], have a look at
+If you have more questions about [tinted-builder-rust], have a look at
 the information on the GitHub page.
 
-## Submitting a PR
-
-- Run the colorscheme generation using [base16-builder-go][1] and commit
-  the changes in your PR. Don't make changes directly to the generated
-  colorschemes, make changes to the template instead.
-- Please abide by what's requested in the [PR template][4].
-
-## Submitting an issue
-
-Please follow the instructions in the issue templates:
-
-- [Issue template for bug reports][5]
-- [Issue template for feature requests][6]
-
-[1]: https://github.com/tinted-theming/base16-builder-go
-[2]: https://github.com/tinted-theming/base16-schemes
-[3]: .github/workflows/update.yml
-[4]: .github/pull_request_template.md
-[5]: .github/ISSUE_TEMPLATE/bug_report.md
-[6]: .github/ISSUE_TEMPLATE/feature_request.md
+[tinted-builder-rust]: https://github.com/tinted-theming/tinted-builder-rust
+[tinted-schemes]: https://github.com/tinted-theming/schemes
+[GitHub Action]: .github/workflows/update.yml


### PR DESCRIPTION
We've built `tinted-builder-rust` and are using it as the primary build so this PR switches it out in the workflow action file and updates the contribution readme. There are also various ways of installing, including cargo, homebrew as well as binaries on GitHub release page. https://github.com/tinted-theming/tinted-builder-rust